### PR TITLE
Add install hook to create Search API field

### DIFF
--- a/domain_search.module
+++ b/domain_search.module
@@ -1,9 +1,12 @@
+<?php
+
+use Drupal\domain_access\DomainAccessManager;
 use Drupal\search_api\Entity\Index;
 use Drupal\search_api\Item\Field;
 
 /**
-Implements hook_install()
-*/
+ *  Implements hook_install()
+ */
 function domain_search_install()
 {
     create_domain_ids_search_api_field();
@@ -12,11 +15,12 @@ function domain_search_install()
 function create_domain_ids_search_api_field()
 {
     $index = Index::load('default_solr_index');
-    if ($index->getField('domain_ids')) { return; }
-    $field = new Field($index, 'domain_ids');
+    if ($index->getField(DomainAccessManager::DOMAIN_ACCESS_FIELD)) { return; }
+    $field = new Field($index, DomainAccessManager::DOMAIN_ACCESS_FIELD);
     $field->setType('string');
-    $field->setPropertyPath('domain_ids');
+    $field->setDatasourceId('entity:node');
+    $field->setPropertyPath(DomainAccessManager::DOMAIN_ACCESS_FIELD);
     $field->setLabel('Domain IDs');
     $index->addField($field);
-    $index->save();
+    $res = $index->save();
 }

--- a/domain_search.module
+++ b/domain_search.module
@@ -1,0 +1,22 @@
+use Drupal\search_api\Entity\Index;
+use Drupal\search_api\Item\Field;
+
+/**
+Implements hook_install()
+*/
+function domain_search_install()
+{
+    create_domain_ids_search_api_field();
+}
+
+function create_domain_ids_search_api_field()
+{
+    $index = Index::load('default_solr_index');
+    if ($index->getField('domain_ids')) { return; }
+    $field = new Field($index, 'domain_ids');
+    $field->setType('string');
+    $field->setPropertyPath('domain_ids');
+    $field->setLabel('Domain IDs');
+    $index->addField($field);
+    $index->save();
+}

--- a/domain_search.module
+++ b/domain_search.module
@@ -14,13 +14,16 @@ function domain_search_install()
 
 function create_domain_ids_search_api_field()
 {
-    $index = Index::load('default_solr_index');
-    if ($index->getField(DomainAccessManager::DOMAIN_ACCESS_FIELD)) { return; }
-    $field = new Field($index, DomainAccessManager::DOMAIN_ACCESS_FIELD);
-    $field->setType('string');
-    $field->setDatasourceId('entity:node');
-    $field->setPropertyPath(DomainAccessManager::DOMAIN_ACCESS_FIELD);
-    $field->setLabel('Domain IDs');
-    $index->addField($field);
-    $res = $index->save();
+    $indexes = \Drupal::entityTypeManager()->getStorage('search_api_index')->loadMultiple();
+    foreach ($indexes as $index) {
+        if (!in_array('entity:node', $index->getDatasourceIds())) { continue; }
+        if ($index->getField(DomainAccessManager::DOMAIN_ACCESS_FIELD)) { continue; }
+        $field = new Field($index, DomainAccessManager::DOMAIN_ACCESS_FIELD);
+        $field->setType('string');
+        $field->setDatasourceId('entity:node');
+        $field->setPropertyPath(DomainAccessManager::DOMAIN_ACCESS_FIELD);
+        $field->setLabel('Domain IDs');
+        $index->addField($field);
+        $index->save();
+    }
 }

--- a/src/EventSubscriber/DomainSearchSubscriber.php
+++ b/src/EventSubscriber/DomainSearchSubscriber.php
@@ -3,6 +3,7 @@
 namespace Drupal\domain_search\EventSubscriber;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\domain_access\DomainAccessManager;
 use Drupal\search_api\Event\SearchApiEvents;
 use Drupal\search_api\Event\IndexingItemsEvent;
 use Drupal\search_api\Event\QueryPreExecuteEvent;
@@ -16,13 +17,17 @@ class DomainSearchSubscriber implements EventSubscriberInterface {
   }
 
   public function indexingItems(IndexingItemsEvent $event) {
+    // return;
     foreach ($event->getItems() as $item) {
       $original_object = $item->getOriginalObject(true);
-      $item->setField('domain_ids', $original_object->domains);
+      $entity = $original_object->getEntity();
+      $domains = DomainAccessManager::getAccessValues($entity);
+      $item->setField('domain_ids', $domains);
     }
   }
 
   public function executingQuery(QueryPreExecuteEvent $event) {
+    // return;
     $domain_negotiator = \Drupal::service('domain.negotiator');
     $domain_id = $domain_negotiator->getActiveId();
     $query = $event->getQuery();

--- a/src/EventSubscriber/DomainSearchSubscriber.php
+++ b/src/EventSubscriber/DomainSearchSubscriber.php
@@ -16,10 +16,12 @@ class DomainSearchSubscriber implements EventSubscriberInterface {
   }
 
   public function executingQuery(QueryPreExecuteEvent $event) {
-    $domain_negotiator = \Drupal::service('domain.negotiator');
-    $domain_id = $domain_negotiator->getActiveId();
     $query = $event->getQuery();
-    $conditions = $query->createAndAddConditionGroup();
-    $conditions->addCondition(DomainAccessManager::DOMAIN_ACCESS_FIELD, $domain_id, 'IN');
+    if ($query->getIndex()->getField(DomainAccessManager::DOMAIN_ACCESS_FIELD)) {
+      $domain_negotiator = \Drupal::service('domain.negotiator');
+      $domain_id = $domain_negotiator->getActiveId();
+      $conditions = $query->createAndAddConditionGroup();
+      $conditions->addCondition(DomainAccessManager::DOMAIN_ACCESS_FIELD, $domain_id, 'IN');
+    }
   }
 }

--- a/src/EventSubscriber/DomainSearchSubscriber.php
+++ b/src/EventSubscriber/DomainSearchSubscriber.php
@@ -11,20 +11,8 @@ use Drupal\search_api\Event\QueryPreExecuteEvent;
 class DomainSearchSubscriber implements EventSubscriberInterface {
   public static function getSubscribedEvents() {
     return [
-      // SearchApiEvents::INDEXING_ITEMS => 'indexingItems',
       SearchApiEvents::QUERY_PRE_EXECUTE => 'executingQuery'
     ];
-  }
-
-  // commented out because it appears this is happening automatically - needs investigation
-  public function indexingItems(IndexingItemsEvent $event) {
-    // foreach ($event->getItems() as $item) {
-    //   $original_object = $item->getOriginalObject(true);
-    //   $entity = $original_object->getEntity();
-    //   $domains = DomainAccessManager::getAccessValues($entity);
-    //   $field = $item->getField(DomainAccessManager::DOMAIN_ACCESS_FIELD);
-    //   $field->setValues(array_keys($domains));
-    // }
   }
 
   public function executingQuery(QueryPreExecuteEvent $event) {

--- a/src/EventSubscriber/DomainSearchSubscriber.php
+++ b/src/EventSubscriber/DomainSearchSubscriber.php
@@ -11,27 +11,27 @@ use Drupal\search_api\Event\QueryPreExecuteEvent;
 class DomainSearchSubscriber implements EventSubscriberInterface {
   public static function getSubscribedEvents() {
     return [
-      SearchApiEvents::INDEXING_ITEMS => 'indexingItems',
+      // SearchApiEvents::INDEXING_ITEMS => 'indexingItems',
       SearchApiEvents::QUERY_PRE_EXECUTE => 'executingQuery'
     ];
   }
 
+  // commented out because it appears this is happening automatically - needs investigation
   public function indexingItems(IndexingItemsEvent $event) {
-    // return;
-    foreach ($event->getItems() as $item) {
-      $original_object = $item->getOriginalObject(true);
-      $entity = $original_object->getEntity();
-      $domains = DomainAccessManager::getAccessValues($entity);
-      $item->setField('domain_ids', $domains);
-    }
+    // foreach ($event->getItems() as $item) {
+    //   $original_object = $item->getOriginalObject(true);
+    //   $entity = $original_object->getEntity();
+    //   $domains = DomainAccessManager::getAccessValues($entity);
+    //   $field = $item->getField(DomainAccessManager::DOMAIN_ACCESS_FIELD);
+    //   $field->setValues(array_keys($domains));
+    // }
   }
 
   public function executingQuery(QueryPreExecuteEvent $event) {
-    // return;
     $domain_negotiator = \Drupal::service('domain.negotiator');
     $domain_id = $domain_negotiator->getActiveId();
     $query = $event->getQuery();
     $conditions = $query->createAndAddConditionGroup();
-    $conditions->addCondition('domain_ids', $domain_id, 'IN');
+    $conditions->addCondition(DomainAccessManager::DOMAIN_ACCESS_FIELD, $domain_id, 'IN');
   }
 }


### PR DESCRIPTION
Setting the DatasourceId and PropertyPath on the field definition lets the Search API know where to find the data for indexing, so the subscription for the INDEXING_ITEMS event isn't necessary.